### PR TITLE
Fix a bug by replacing one Python dependency

### DIFF
--- a/clean-container-artifacts.sh
+++ b/clean-container-artifacts.sh
@@ -1,0 +1,4 @@
+podman container rm -f \
+    container-m-j-2-postgres
+
+podman volume prune

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ packaging==23.2
 pathspec==0.12.0
 platformdirs==4.1.0
 pluggy==1.3.0
-psycopg2==2.9.9
+psycopg2-binary==2.9.9
 pytest==7.4.3
 pytest-cov==4.1.0
 pytest-django==4.7.0


### PR DESCRIPTION
in [the preceding pull request titled "Switch the database engine from SQLite to PostgreSQL"](
  https://github.com/kaloyan-marinov/mini-jira-2/pull/2
),
the `psycopg2==2.9.9` Python package was added to `requirements.txt`

however,
it _appears_ that
that package allows the web application to connect to a PostgreSQL container
_only if_ the host operating system itself contains a PostgreSQL installation;
that condition defeats the purpose of connecting to a containerized PostgreSQL server;

this pull request dispenses with the above-mentioned condition