### PR TITLE
Protect the endpoints that operate upon `Task` resources

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,3 +7,10 @@ POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
 POSTGRES_DB=  # specify a value, and control who has access to it
 POSTGRES_USER=  # specify a value, and control who has access to it
 POSTGRES_PASSWORD=  # specify a value, and control who has access to it
+
+# Specify values for a toy/sample user,
+# which is to be created within the database
+# by the web application.
+USERNAME=
+EMAIL=
+PASSWORD=

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "."
+            },
+            "program": "${workspaceFolder}/src/manage.py",
+            "args": [
+                "runserver"
+            ],
+            "django": true,
+            "justMyCode": false
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ $ utility-scripts/populate-db.sh
 # one-by-one and in the same order as they appear in inside the script.
 ```
 
+```bash
+# Provide the values of `USERNAME`, `EMAIL`, `PASSWORD`
+# from the `.env` file.
+(venv) $ PYTHONPATH=. src/manage.py shell
+Python 3.8.3 (v3.8.3:6f8c8320e9, May 13 2020, 16:29:34) 
+[Clang 6.0 (clang-600.0.57)] on darwin
+Type "help", "copyright", "credits" or "license" for more information.
+(InteractiveConsole)
+>>> from django.contrib.auth.models import User
+>>> user = User.objects.create_user(
+...     os.environ.get("USERNAME"),
+...     os.environ.get("EMAIL"),
+...     os.environ.get("PASSWORD"),
+... )
+>>> exit()
+```
+
 # How to run a containerized version of the project
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ TOTAL                                    104     24     22      6    75%
 ============================== 6 passed in 4.06s ===============================
 ```
 
+Run a single class of test cases:
+```bash
+(venv) $ PYTHONPATH=. pytest \
+   tests/tasks/test_views.py::Test_1_ProcessTasks
+# ...
+```
+
 Run an individual test case:
 ```bash
 (venv) $ PYTHONPATH=. pytest \
-   tests/tasks/test_views.py::test_process_tasks_1_post
+   tests/tasks/test_views.py::Test_1_ProcessTasks::test_post
 # ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ Type "help", "copyright", "credits" or "license" for more information.
 (InteractiveConsole)
 >>> from django.contrib.auth.models import User
 >>> user = User.objects.create_user(
-...     os.environ.get("USERNAME"),
-...     os.environ.get("EMAIL"),
-...     os.environ.get("PASSWORD"),
-... )
+    os.environ.get("USERNAME"),
+    os.environ.get("EMAIL"),
+    os.environ.get("PASSWORD"),
+)
 >>> exit()
 ```
 

--- a/README.md
+++ b/README.md
@@ -326,3 +326,22 @@ Type "help", "copyright", "credits" or "license" for more information.
 # by issuing:
 $ utility-scripts/clean-container-artifacts.sh
 ```
+
+# Future plans
+
+- make it possible
+  to run the containerized version of the project
+  via Kubernetes
+
+- make it possible
+  to register/create a new `User` by issuing HTTP requests to the web application
+
+- create a Django app called `frontend`
+  that - by utilizing <ins>pure-Django</ins> session-based authentication! -
+  allows users to use their web browsers
+  in order to register, manage their passwords, log in, and log out
+  (
+  whereby the `SessionAuthentication`,
+  which the Django REST Framework is configured to use,
+  will "play nice" with the <ins>pure-Django</ins> session-based authentication
+  )

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Python 3.8.3 (v3.8.3:6f8c8320e9, May 13 2020, 16:29:34)
 [Clang 6.0 (clang-600.0.57)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
 (InteractiveConsole)
+>>> import os
 >>> from django.contrib.auth.models import User
 >>> user = User.objects.create_user(
     os.environ.get("USERNAME"),

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Indexes:
 ```bash
 # Provide the values of `USERNAME`, `EMAIL`, `PASSWORD`
 # from the `.env` file.
-(venv) $ PYTHONPATH=. src/manage.py shell
+(venv) $ PYTHONPATH=. python src/manage.py shell
 Python 3.8.3 (v3.8.3:6f8c8320e9, May 13 2020, 16:29:34) 
 [Clang 6.0 (clang-600.0.57)] on darwin
 Type "help", "copyright", "credits" or "license" for more information.
@@ -271,7 +271,7 @@ $ DB_ENGINE_HOST=mini-jira-2-database-server bash -c '
 ```
 
 ```bash
-$ export HYPHENATED_YYYY_MM_DD_HH_MM=2023-12-17-09-01
+$ export HYPHENATED_YYYY_MM_DD_HH_MM=2024-01-01-10-35
 ```
 
 ```bash
@@ -293,9 +293,32 @@ $ DB_ENGINE_HOST=mini-jira-2-database-server bash -c '
    '
 
 # Launch another terminal instance
-# and, in it,
-# you may issue requests to the web application
-# in the way that is described at the end of the previous section.
+# and, in it:
+# (a) Provide the values of `USERNAME`, `EMAIL`, `PASSWORD`
+#     from the `.env` file.
+$ podman container exec \
+   -it \
+   container-mini-jira-2 \
+   /bin/bash
+
+root@<container-id> python src/manage.py shell
+Python 3.8.3 (v3.8.3:6f8c8320e9, May 13 2020, 16:29:34) 
+[Clang 6.0 (clang-600.0.57)] on darwin
+Type "help", "copyright", "credits" or "license" for more information.
+(InteractiveConsole)
+>>> import os
+>>> from django.contrib.auth.models import User
+>>> user = User.objects.create_user(
+    os.environ.get("USERNAME"),
+    os.environ.get("EMAIL"),
+    os.environ.get("PASSWORD"),
+)
+>>> exit()
+```
+
+```bash
+# (b) You may issue requests to the web application
+#     in the way that is described at the end of the previous section.
 
 # Stop running all containers,
 # remove the created volume,

--- a/README.md
+++ b/README.md
@@ -211,19 +211,6 @@ Indexes:
 ```
 
 ```bash
-# Launch a third terminal instance and, in it, start serving the application:
-(venv) $ PYTHONPATH=. python src/manage.py runserver
-```
-
-```bash
-# Launch a fourth terminal instance and, in it, issue requests to the application
-# either by running the utility script:
-$ utility-scripts/populate-db.sh
-# or by copying the commands from that script and executing them
-# one-by-one and in the same order as they appear in inside the script.
-```
-
-```bash
 # Provide the values of `USERNAME`, `EMAIL`, `PASSWORD`
 # from the `.env` file.
 (venv) $ PYTHONPATH=. src/manage.py shell
@@ -239,6 +226,19 @@ Type "help", "copyright", "credits" or "license" for more information.
     os.environ.get("PASSWORD"),
 )
 >>> exit()
+```
+
+```bash
+# Launch a third terminal instance and, in it, start serving the application:
+(venv) $ PYTHONPATH=. python src/manage.py runserver
+```
+
+```bash
+# Launch a fourth terminal instance and, in it, issue requests to the application
+# either by running the utility script:
+$ utility-scripts/populate-db.sh
+# or by copying the commands from that script and executing them
+# one-by-one and in the same order as they appear in inside the script.
 ```
 
 # How to run a containerized version of the project

--- a/src/auth_subsystem/admin.py
+++ b/src/auth_subsystem/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/src/auth_subsystem/apps.py
+++ b/src/auth_subsystem/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AuthSubsystemConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "auth_subsystem"

--- a/src/auth_subsystem/models.py
+++ b/src/auth_subsystem/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/src/auth_subsystem/tests.py
+++ b/src/auth_subsystem/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/src/auth_subsystem/urls.py
+++ b/src/auth_subsystem/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path(
+        "sign_in",
+        views.sign_in,
+        name="sign-in",
+    ),
+]

--- a/src/auth_subsystem/views.py
+++ b/src/auth_subsystem/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/src/auth_subsystem/views.py
+++ b/src/auth_subsystem/views.py
@@ -1,3 +1,28 @@
 from django.shortcuts import render
+from django.contrib.auth import authenticate, login
 
-# Create your views here.
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+
+@api_view(["POST"])
+def sign_in(request):
+    # username = request.POST["username"]
+    # password = request.POST["password"]
+    username = request.data.get("username")
+    password = request.data.get("password")
+    user = authenticate(request, username=username, password=password)
+    if user is not None:
+        login(request, user)
+        return Response(
+            status=204,
+        )
+    else:
+        # Return an 'invalid login' error message.
+        return Response(
+            data={
+                "error": "Unauthorized",
+                "message": "Your attempt at using BasicAuthentication failed.",
+            },
+            status=401,
+        )

--- a/src/auth_subsystem/views.py
+++ b/src/auth_subsystem/views.py
@@ -7,8 +7,6 @@ from rest_framework.response import Response
 
 @api_view(["POST"])
 def sign_in(request):
-    # username = request.POST["username"]
-    # password = request.POST["password"]
     username = request.data.get("username")
     password = request.data.get("password")
     user = authenticate(request, username=username, password=password)
@@ -18,7 +16,6 @@ def sign_in(request):
             status=204,
         )
     else:
-        # Return an 'invalid login' error message.
         return Response(
             data={
                 "error": "Unauthorized",

--- a/src/mini_jira_2/settings.py
+++ b/src/mini_jira_2/settings.py
@@ -148,3 +148,13 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+    ]
+}
+
+# AUTHENTICATION_BACKENDS = [
+#     "django.contrib.auth.backends.ModelBackend",
+# ]

--- a/src/mini_jira_2/settings.py
+++ b/src/mini_jira_2/settings.py
@@ -154,7 +154,3 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ]
 }
-
-# AUTHENTICATION_BACKENDS = [
-#     "django.contrib.auth.backends.ModelBackend",
-# ]

--- a/src/mini_jira_2/urls.py
+++ b/src/mini_jira_2/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("src.tasks.urls")),
+    path("api/", include("src.auth_subsystem.urls")),
 ]

--- a/src/tasks/urls.py
+++ b/src/tasks/urls.py
@@ -12,9 +12,4 @@ urlpatterns = [
         views.process_task,
         name="process-task",
     ),
-    path(
-        "sign_in",
-        views.sign_in,
-        name="sign-in",
-    ),
 ]

--- a/src/tasks/urls.py
+++ b/src/tasks/urls.py
@@ -12,4 +12,9 @@ urlpatterns = [
         views.process_task,
         name="process-task",
     ),
+    path(
+        "sign_in",
+        views.sign_in,
+        name="sign-in",
+    ),
 ]

--- a/src/tasks/views.py
+++ b/src/tasks/views.py
@@ -1,36 +1,10 @@
 from django.shortcuts import render
-from django.contrib.auth.decorators import login_required
-from django.contrib.auth.models import AnonymousUser
-from django.contrib.auth import authenticate, login
 
 from rest_framework.decorators import api_view, authentication_classes
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
 
 from .models import Task
-
-
-@api_view(["POST"])
-def sign_in(request):
-    # username = request.POST["username"]
-    # password = request.POST["password"]
-    username = request.data.get("username")
-    password = request.data.get("password")
-    user = authenticate(request, username=username, password=password)
-    if user is not None:
-        login(request, user)
-        return Response(
-            status=204,
-        )
-    else:
-        # Return an 'invalid login' error message.
-        return Response(
-            data={
-                "error": "Unauthorized",
-                "message": "Your attempt at using BasicAuthentication failed.",
-            },
-            status=401,
-        )
 
 
 @api_view(["GET", "POST"])

--- a/src/tasks/views.py
+++ b/src/tasks/views.py
@@ -63,7 +63,17 @@ def process_tasks(request):
 
 
 @api_view(["GET", "PUT", "DELETE"])
+@authentication_classes([SessionAuthentication])
 def process_task(request, task_id):
+    if not request.user.is_authenticated:
+        return Response(
+            data={
+                "error": "Unauthorized",
+                "message": "Your attempt at using SessionAuthentication failed.",
+            },
+            status=401,
+        )
+
     t = Task.objects.get(id=task_id)
 
     if request.method == "GET":

--- a/src/tasks/views.py
+++ b/src/tasks/views.py
@@ -9,9 +9,7 @@ from .models import Task
 
 @api_view(["GET", "POST"])
 @authentication_classes([SessionAuthentication])
-# @login_required
 def process_tasks(request):
-    # if isinstance(request.user, AnonymousUser):
     if not request.user.is_authenticated:
         return Response(
             data={

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -74,7 +74,7 @@ from src.tasks.models import Task
 
 
 @pytest.mark.django_db
-def test_process_tasks_1_post():
+def test_process_tasks_1_post(admin_client):
     """
     If the request body contains values for each of 'category' and 'description',
     then a new `Task` should be created successfully.
@@ -84,7 +84,7 @@ def test_process_tasks_1_post():
     client = Client()
 
     # Act.
-    response = client.post(
+    response = admin_client.post(
         "/api/tasks",
         data={
             "category": "health",
@@ -102,7 +102,7 @@ def test_process_tasks_1_post():
 
 
 @pytest.mark.django_db
-def test_process_tasks_2_get():
+def test_process_tasks_2_get(admin_client):
     """
     If no `Task`s have been created,
     then getting all `Task`s should return an empty list.
@@ -112,7 +112,7 @@ def test_process_tasks_2_get():
     client = Client()
 
     # Act.
-    response = client.get("/api/tasks")
+    response = admin_client.get("/api/tasks")
 
     # Assert.
     assert response.status_code == 200
@@ -122,7 +122,7 @@ def test_process_tasks_2_get():
 
 
 @pytest.mark.django_db
-def test_process_tasks_3_get():
+def test_process_tasks_3_get(admin_client):
     """
     If `Task`s have been created,
     then getting all `Task`s should return
@@ -132,7 +132,7 @@ def test_process_tasks_3_get():
     # Arrange.
     client = Client()
 
-    _ = client.post(
+    _ = admin_client.post(
         "/api/tasks",
         data={
             "category": "health",
@@ -140,7 +140,7 @@ def test_process_tasks_3_get():
         },
     )
 
-    _ = client.post(
+    _ = admin_client.post(
         "/api/tasks",
         data={
             "category": "work",
@@ -149,7 +149,7 @@ def test_process_tasks_3_get():
     )
 
     # Act.
-    response = client.get("/api/tasks")
+    response = admin_client.get("/api/tasks")
 
     # Assert.
     assert response.status_code == 200
@@ -170,7 +170,7 @@ def test_process_tasks_3_get():
 
 
 @pytest.mark.django_db
-def test_process_task_1_get():
+def test_process_task_1_get(admin_client):
     """
     Requesting to retrieve an existing `Task`
     should return a representation of that `Task`.
@@ -179,7 +179,7 @@ def test_process_task_1_get():
     # Arrange.
     client = Client()
 
-    _ = client.post(
+    _ = admin_client.post(
         "/api/tasks",
         data={
             "category": "health",
@@ -188,7 +188,7 @@ def test_process_task_1_get():
     )
 
     # Act.
-    response = client.get("/api/tasks/1")
+    response = admin_client.get("/api/tasks/1")
 
     # Assert.
     assert response.status_code == 200
@@ -200,11 +200,11 @@ def test_process_task_1_get():
 
 
 @pytest.mark.django_db
-def test_process_task_2_put():
+def test_process_task_2_put(admin_client):
     # Arrange.
     client = Client()
 
-    _ = client.post(
+    _ = admin_client.post(
         "/api/tasks",
         data={
             "category": "helthh",
@@ -213,7 +213,7 @@ def test_process_task_2_put():
     )
 
     # Act.
-    response = client.put(
+    response = admin_client.put(
         "/api/tasks/1",
         data={
             "category": "health",
@@ -236,11 +236,11 @@ def test_process_task_2_put():
 
 
 @pytest.mark.django_db
-def test_process_task_3_delete():
+def test_process_task_3_delete(admin_client):
     # Arrange.
     client = Client()
 
-    _ = client.post(
+    _ = admin_client.post(
         "/api/tasks",
         data={
             "category": "health",
@@ -249,7 +249,7 @@ def test_process_task_3_delete():
     )
 
     # Act.
-    response = client.delete("/api/tasks/1")
+    response = admin_client.delete("/api/tasks/1")
 
     # Assert.
     assert response.status_code == 204

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -74,7 +74,7 @@ from src.tasks.models import Task
 
 
 @pytest.mark.django_db
-def test_process_tasks_1_post(admin_client):
+def test_process_tasks_1_post():
     """
     If the request body contains values for each of 'category' and 'description',
     then a new `Task` should be created successfully.
@@ -84,7 +84,7 @@ def test_process_tasks_1_post(admin_client):
     client = Client()
 
     # Act.
-    response = admin_client.post(
+    response = client.post(
         "/api/tasks",
         data={
             "category": "health",

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -139,7 +139,7 @@ class Test_1_ProcessTasks(TestBase):
             # '''
             # # https://stackoverflow.com/questions/26639169/csrf-failed-csrf-token-missing-or-incorrect/26639895#26639895
             # headers={
-            #     "Cookie": f"sessionid={session_id}; csrftoken={csrf_token};",
+            #     "Cookie": f"sessionid={self.session_id}; csrftoken={self.csrf_token};",
             # },
             # '''
             # # fmt: on

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -118,7 +118,15 @@ def test_process_tasks_1_post():
 
     # client_cookies = client.cookies
 
+    # As per [this](
+    #   https://stackoverflow.com/questions/19616817/testing-django-application-cookies-sessions-and-states
+    # ),
+    # the following statement should not be used in this test:
+    # fmt: off
+    '''
     client.logout()
+    '''
+    # fmt: on
 
     # Act.
     response = client.post(
@@ -127,10 +135,14 @@ def test_process_tasks_1_post():
             "category": "health",
             "description": "go to the doctor",
         },
-        # https://stackoverflow.com/questions/26639169/csrf-failed-csrf-token-missing-or-incorrect/26639895#26639895
-        headers={
-            "Cookie": f"sessionid={session_id}; csrftoken={csrf_token};",
-        },
+        # # fmt: off
+        # '''
+        # # https://stackoverflow.com/questions/26639169/csrf-failed-csrf-token-missing-or-incorrect/26639895#26639895
+        # headers={
+        #     "Cookie": f"sessionid={session_id}; csrftoken={csrf_token};",
+        # },
+        # '''
+        # # fmt: on
     )
 
     # Assert.

--- a/tests/tasks/test_views.py
+++ b/tests/tasks/test_views.py
@@ -109,6 +109,17 @@ def test_process_tasks_1_post():
     csrf_token = response_.cookies["csrftoken"].value
     session_id = response_.cookies["sessionid"].value
 
+    # from django.contrib.sessions.backends.db import SessionStore
+    # from django.contrib.sessions.models import Session
+
+    # client_session = Session.objects.get(
+    #     pk=client.session.session_key,
+    # )
+
+    # client_cookies = client.cookies
+
+    client.logout()
+
     # Act.
     response = client.post(
         "/api/tasks",
@@ -117,9 +128,9 @@ def test_process_tasks_1_post():
             "description": "go to the doctor",
         },
         # https://stackoverflow.com/questions/26639169/csrf-failed-csrf-token-missing-or-incorrect/26639895#26639895
-        # headers={
-        #     "Cookie": f"sessionid={session_id}; csrftoken={csrf_token};",
-        # },
+        headers={
+            "Cookie": f"sessionid={session_id}; csrftoken={csrf_token};",
+        },
     )
 
     # Assert.

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -31,14 +31,20 @@ cat ${TEMP_FILE}
 # in order to
 # extract the CSRF token,
 # which is contained in the preceding command's output.
-regex="Set-Cookie:  csrftoken=([0-9a-zA-Z]+);"
-line_with_csrf_token=$(grep "Set-Cookie:  csrftoken" $TEMP_FILE)
-if [[ $line_with_csrf_token =~ $regex ]]
+reg_exp_for_csrf_token="csrftoken=([0-9a-zA-Z]+);"
+line_with_csrf_token=$(
+   grep \
+      --extended-regexp \
+      $reg_exp_for_csrf_token \
+      $TEMP_FILE
+)
+if [[ $line_with_csrf_token =~ $reg_exp_for_csrf_token ]]
 then
    CSRF_TOKEN="${BASH_REMATCH[1]}"
    echo "identified the CSRF token to be equal to ${CSRF_TOKEN}"
 else
-   echo "$line_with_csrf_token doesn't match" >&2
+   echo "no match found in '$line_with_csrf_token' - aborting!" >&2
+   exit 1
 fi
 
 # Adapt the example from
@@ -46,14 +52,20 @@ fi
 # in order to
 # extract the Session ID,
 # which is contained in the preceding command's output.
-regex="Set-Cookie:  sessionid=([0-9a-zA-Z]+);"
-line_with_session_id=$(grep "Set-Cookie:  sessionid" $TEMP_FILE)
-if [[ $line_with_session_id =~ $regex ]]
+reg_exp_for_session_id="sessionid=([0-9a-zA-Z]+);"
+line_with_session_id=$(
+   grep \
+      --extended-regexp \
+      $reg_exp_for_session_id \
+      $TEMP_FILE
+)
+if [[ $line_with_session_id =~ $reg_exp_for_session_id ]]
 then
    SESSION_ID="${BASH_REMATCH[1]}"
    echo "identified the Session ID to be equal to ${SESSION_ID}"
 else
-   echo "$line_with_session_id doesn't match" >&2
+   echo "no match found in '$line_with_session_id' - aborting!" >&2
+   exit 1
 fi
 
 rm ${TEMP_FILE}

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -12,6 +12,8 @@ http POST \
 
 export SESSION_ID=<tbd>
 
+export CSRF_TOKEN=<tbd>
+
 http \
    localhost:8000/api/tasks \
    cookie:sessionid=${SESSION_ID}
@@ -53,6 +55,8 @@ curl \
    --verbose \
    --request POST \
    --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    --data '{
       "category": "health",
       "description": "go to the doctor"
@@ -76,6 +80,8 @@ curl \
    --verbose \
    --request POST \
    --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    --data '{
       "category": "work",
       "description": "build a web application using Django"
@@ -122,6 +128,8 @@ curl \
    --verbose \
    --request POST \
    --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    --data '{
       "category": "VACATON",
       "description": "look up INTRESTING towns in SICLY to VISITT"
@@ -158,6 +166,8 @@ curl \
    --verbose \
    --request PUT \
    --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    --data '{
       "category": "vacation",
       "description": "look up interesting towns in Sicily to visit"

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -1,3 +1,5 @@
+source .env
+
 # Arrange for every command to be printed before it is executed.
 set -o xtrace
 
@@ -16,6 +18,11 @@ curl \
    }" \
    localhost:8000/api/sign_in
 
+# # ...
+# < HTTP/1.1 204 No Content
+# # ...
+# <no output>
+# ```
 
 # Extract the CSRF token,
 # which is contained in the preceding command's output.
@@ -29,7 +36,6 @@ else
    echo "$line_with_csrf_token doesn't match" >&2
 fi
 
-
 # Extract the Session ID,
 # which is contained in the preceding command's output.
 regex="Set-Cookie:  sessionid=([0-9a-zA-Z]+);"
@@ -42,195 +48,192 @@ else
    echo "$line_with_session_id doesn't match" >&2
 fi
 
-# rm ${TEMP_FILE}
-# 
-# http \
-#    localhost:8000/api/tasks \
-#    cookie:sessionid=${SESSION_ID}
+rm ${TEMP_FILE}
 
-# echo ""
-# curl \
-#    --verbose \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    localhost:8000/api/tasks \
-#    | json_pp
+echo ""
+curl \
+   --verbose \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   localhost:8000/api/tasks \
+   | json_pp
 
-# # # ...
-# # < HTTP/1.1 200 OK
-# # # ...
-# # {
-# #    "items" : []
-# # }
+# # ...
+# < HTTP/1.1 200 OK
+# # ...
+# {
+#    "items" : []
+# }
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request POST \
-#    --header "Content-Type: application/json" \
-#    --data '{
-#       "category": "health"
-#    }' \
-#    localhost:8000/api/tasks \
-#    | json_pp
+echo ""
+curl \
+   --verbose \
+   --request POST \
+   --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   --data '{
+      "category": "health"
+   }' \
+   localhost:8000/api/tasks \
+   | json_pp
 
-# # # ...
-# # < HTTP/1.1 400 Bad Request
-# # # ...
-# # {
-# #    "error" : "Bad Request",
-# #    "message" : "The request body has to provide values for each of 'category' and 'description'."
-# # }
+# # ...
+# < HTTP/1.1 400 Bad Request
+# # ...
+# {
+#    "error" : "Bad Request",
+#    "message" : "The request body has to provide values for each of 'category' and 'description'."
+# }
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request POST \
-#    --header "Content-Type: application/json" \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    --data '{
-#       "category": "health",
-#       "description": "go to the doctor"
-#    }' \
-#    localhost:8000/api/tasks \
-#    | json_pp
+echo ""
+curl \
+   --verbose \
+   --request POST \
+   --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   --data '{
+      "category": "health",
+      "description": "go to the doctor"
+   }' \
+   localhost:8000/api/tasks \
+   | json_pp
 
-# # # ...
-# # < HTTP/1.1 201 Created
-# # # ...
-# # {
-# #    "category" : "health",
-# #    "description" : "go to the doctor",
-# #    "id" : 1
-# # }
+# # ...
+# < HTTP/1.1 201 Created
+# # ...
+# {
+#    "category" : "health",
+#    "description" : "go to the doctor",
+#    "id" : 1
+# }
 
 
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request POST \
-#    --header "Content-Type: application/json" \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    --data '{
-#       "category": "work",
-#       "description": "build a web application using Django"
-#    }' \
-#    localhost:8000/api/tasks \
-#    | json_pp
+echo ""
+curl \
+   --verbose \
+   --request POST \
+   --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   --data '{
+      "category": "work",
+      "description": "build a web application using Django"
+   }' \
+   localhost:8000/api/tasks \
+   | json_pp
 
-# # # ...
-# # < HTTP/1.1 201 Created
-# # # ...
-# # {
-# #    "category" : "work",
-# #    "description" : "build a web application using Django",
-# #    "id" : 2
-# # }
+# # ...
+# < HTTP/1.1 201 Created
+# # ...
+# {
+#    "category" : "work",
+#    "description" : "build a web application using Django",
+#    "id" : 2
+# }
 
-# echo ""
-# curl \
-#    --verbose \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    localhost:8000/api/tasks \
-#    | json_pp
+echo ""
+curl localhost:8000/api/tasks \
+   --verbose \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   | json_pp
 
-# # # ...
-# # < HTTP/1.1 200 OK
-# # # ...
-# # {
-# #    "items" : [
-# #       {
-# #          "category" : "health",
-# #          "description" : "go to the doctor",
-# #          "id" : 1
-# #       },
-# #       {
-# #          "category" : "work",
-# #          "description" : "build a web application using Django",
-# #          "id" : 2
-# #       }
-# #    ]
-# # }
-
+# # ...
+# < HTTP/1.1 200 OK
+# # ...
+# {
+#    "items" : [
+#       {
+#          "category" : "health",
+#          "description" : "go to the doctor",
+#          "id" : 1
+#       },
+#       {
+#          "category" : "work",
+#          "description" : "build a web application using Django",
+#          "id" : 2
+#       }
+#    ]
+# }
 
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request POST \
-#    --header "Content-Type: application/json" \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    --data '{
-#       "category": "VACATON",
-#       "description": "look up INTRESTING towns in SICLY to VISITT"
-#    }' \
-#    localhost:8000/api/tasks \
-#    | json_pp
 
-# # # ...
-# # < HTTP/1.1 201 Created
-# # # ...
-# # {
-# #    "category" : "VACATON",
-# #    "description" : "look up INTRESTING towns in SICLY to VISITT",
-# #    "id" : 3
-# # }
+echo ""
+curl \
+   --verbose \
+   --request POST \
+   --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   --data '{
+      "category": "VACATON",
+      "description": "look up INTRESTING towns in SICLY to VISITT"
+   }' \
+   localhost:8000/api/tasks \
+   | json_pp
 
-# echo ""
-# curl \
-#    --verbose \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    localhost:8000/api/tasks/3 \
-#    | json_pp
+# # ...
+# < HTTP/1.1 201 Created
+# # ...
+# {
+#    "category" : "VACATON",
+#    "description" : "look up INTRESTING towns in SICLY to VISITT",
+#    "id" : 3
+# }
 
-# # # ...
-# # < HTTP/1.1 200 OK
-# # # ...
-# # {
-# #    "category" : "VACATON",
-# #    "description" : "look up INTRESTING towns in SICLY to VISITT",
-# #    "id" : 3
-# # }
+echo ""
+curl \
+   --verbose \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   localhost:8000/api/tasks/3 \
+   | json_pp
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request PUT \
-#    --header "Content-Type: application/json" \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    --data '{
-#       "category": "vacation",
-#       "description": "look up interesting towns in Sicily to visit"
-#    }' \
-#    localhost:8000/api/tasks/3 \
-#    | json_pp
+# # ...
+# < HTTP/1.1 200 OK
+# # ...
+# {
+#    "category" : "VACATON",
+#    "description" : "look up INTRESTING towns in SICLY to VISITT",
+#    "id" : 3
+# }
 
-# # # ...
-# # < HTTP/1.1 200 OK
-# # # ...
-# # {
-# #    "category" : "vacation",
-# #    "description" : "look up interesting towns in Sicily to visit",
-# #    "id" : 3
-# # }
+echo ""
+curl \
+   --verbose \
+   --request PUT \
+   --header "Content-Type: application/json" \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   --data '{
+      "category": "vacation",
+      "description": "look up interesting towns in Sicily to visit"
+   }' \
+   localhost:8000/api/tasks/3 \
+   | json_pp
 
-# echo ""
-# curl \
-#    --verbose \
-#    --request DELETE \
-#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
-#    localhost:8000/api/tasks/2
+# # ...
+# < HTTP/1.1 200 OK
+# # ...
+# {
+#    "category" : "vacation",
+#    "description" : "look up interesting towns in Sicily to visit",
+#    "id" : 3
+# }
 
-# # # ...
-# # < HTTP/1.1 204 No Content
-# # # ...
-# # <no output>
-# # ```
+echo ""
+curl \
+   --verbose \
+   --request DELETE \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
+   localhost:8000/api/tasks/2
+
+# # ...
+# < HTTP/1.1 204 No Content
+# # ...
+# <no output>
+# ```

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -5,6 +5,17 @@ set -o xtrace
 # if any subsequent(*) commands which fail.
 set -e
 
+http POST \
+   localhost:8000/api/sign_in \
+   username=${USERNAME} \
+   password=${PASSWORD}
+
+export SESSION_ID=<tbd>
+
+http \
+   localhost:8000/api/tasks \
+   cookie:sessionid=${SESSION_ID}
+
 echo ""
 curl \
    --verbose \

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -17,201 +17,210 @@ curl \
    localhost:8000/api/sign_in
 
 
+# Extract the CSRF token,
+# which is contained in the preceding command's output.
+regex="Set-Cookie:  csrftoken=([0-9a-zA-Z]+);"
+line_with_csrf_token=$(grep "Set-Cookie:  csrftoken" $TEMP_FILE)
+if [[ $line_with_csrf_token =~ $regex ]]
+then
+   CSRF_TOKEN="${BASH_REMATCH[1]}"
+   echo "identified the CSRF token to be equal to: ${CSRF_TOKEN}"
+else
+   echo "$line_with_csrf_token doesn't match" >&2
+fi
+
+
 export SESSION_ID=<tbd>
 
-export CSRF_TOKEN=<tbd>
+# rm ${TEMP_FILE}
+# 
+# http \
+#    localhost:8000/api/tasks \
+#    cookie:sessionid=${SESSION_ID}
 
-rm ${TEMP_FILE}
+# echo ""
+# curl \
+#    --verbose \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-http \
-   localhost:8000/api/tasks \
-   cookie:sessionid=${SESSION_ID}
+# # # ...
+# # < HTTP/1.1 200 OK
+# # # ...
+# # {
+# #    "items" : []
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   localhost:8000/api/tasks \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --request POST \
+#    --header "Content-Type: application/json" \
+#    --data '{
+#       "category": "health"
+#    }' \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 200 OK
-# # ...
-# {
-#    "items" : []
-# }
+# # # ...
+# # < HTTP/1.1 400 Bad Request
+# # # ...
+# # {
+# #    "error" : "Bad Request",
+# #    "message" : "The request body has to provide values for each of 'category' and 'description'."
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --request POST \
-   --header "Content-Type: application/json" \
-   --data '{
-      "category": "health"
-   }' \
-   localhost:8000/api/tasks \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --request POST \
+#    --header "Content-Type: application/json" \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    --data '{
+#       "category": "health",
+#       "description": "go to the doctor"
+#    }' \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 400 Bad Request
-# # ...
-# {
-#    "error" : "Bad Request",
-#    "message" : "The request body has to provide values for each of 'category' and 'description'."
-# }
-
-echo ""
-curl \
-   --verbose \
-   --request POST \
-   --header "Content-Type: application/json" \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   --data '{
-      "category": "health",
-      "description": "go to the doctor"
-   }' \
-   localhost:8000/api/tasks \
-   | json_pp
-
-# # ...
-# < HTTP/1.1 201 Created
-# # ...
-# {
-#    "category" : "health",
-#    "description" : "go to the doctor",
-#    "id" : 1
-# }
+# # # ...
+# # < HTTP/1.1 201 Created
+# # # ...
+# # {
+# #    "category" : "health",
+# #    "description" : "go to the doctor",
+# #    "id" : 1
+# # }
 
 
 
-echo ""
-curl \
-   --verbose \
-   --request POST \
-   --header "Content-Type: application/json" \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   --data '{
-      "category": "work",
-      "description": "build a web application using Django"
-   }' \
-   localhost:8000/api/tasks \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --request POST \
+#    --header "Content-Type: application/json" \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    --data '{
+#       "category": "work",
+#       "description": "build a web application using Django"
+#    }' \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 201 Created
-# # ...
-# {
-#    "category" : "work",
-#    "description" : "build a web application using Django",
-#    "id" : 2
-# }
+# # # ...
+# # < HTTP/1.1 201 Created
+# # # ...
+# # {
+# #    "category" : "work",
+# #    "description" : "build a web application using Django",
+# #    "id" : 2
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   localhost:8000/api/tasks \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 200 OK
-# # ...
-# {
-#    "items" : [
-#       {
-#          "category" : "health",
-#          "description" : "go to the doctor",
-#          "id" : 1
-#       },
-#       {
-#          "category" : "work",
-#          "description" : "build a web application using Django",
-#          "id" : 2
-#       }
-#    ]
-# }
+# # # ...
+# # < HTTP/1.1 200 OK
+# # # ...
+# # {
+# #    "items" : [
+# #       {
+# #          "category" : "health",
+# #          "description" : "go to the doctor",
+# #          "id" : 1
+# #       },
+# #       {
+# #          "category" : "work",
+# #          "description" : "build a web application using Django",
+# #          "id" : 2
+# #       }
+# #    ]
+# # }
 
 
 
-echo ""
-curl \
-   --verbose \
-   --request POST \
-   --header "Content-Type: application/json" \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   --data '{
-      "category": "VACATON",
-      "description": "look up INTRESTING towns in SICLY to VISITT"
-   }' \
-   localhost:8000/api/tasks \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --request POST \
+#    --header "Content-Type: application/json" \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    --data '{
+#       "category": "VACATON",
+#       "description": "look up INTRESTING towns in SICLY to VISITT"
+#    }' \
+#    localhost:8000/api/tasks \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 201 Created
-# # ...
-# {
-#    "category" : "VACATON",
-#    "description" : "look up INTRESTING towns in SICLY to VISITT",
-#    "id" : 3
-# }
+# # # ...
+# # < HTTP/1.1 201 Created
+# # # ...
+# # {
+# #    "category" : "VACATON",
+# #    "description" : "look up INTRESTING towns in SICLY to VISITT",
+# #    "id" : 3
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   localhost:8000/api/tasks/3 \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    localhost:8000/api/tasks/3 \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 200 OK
-# # ...
-# {
-#    "category" : "VACATON",
-#    "description" : "look up INTRESTING towns in SICLY to VISITT",
-#    "id" : 3
-# }
+# # # ...
+# # < HTTP/1.1 200 OK
+# # # ...
+# # {
+# #    "category" : "VACATON",
+# #    "description" : "look up INTRESTING towns in SICLY to VISITT",
+# #    "id" : 3
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --request PUT \
-   --header "Content-Type: application/json" \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   --data '{
-      "category": "vacation",
-      "description": "look up interesting towns in Sicily to visit"
-   }' \
-   localhost:8000/api/tasks/3 \
-   | json_pp
+# echo ""
+# curl \
+#    --verbose \
+#    --request PUT \
+#    --header "Content-Type: application/json" \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    --data '{
+#       "category": "vacation",
+#       "description": "look up interesting towns in Sicily to visit"
+#    }' \
+#    localhost:8000/api/tasks/3 \
+#    | json_pp
 
-# # ...
-# < HTTP/1.1 200 OK
-# # ...
-# {
-#    "category" : "vacation",
-#    "description" : "look up interesting towns in Sicily to visit",
-#    "id" : 3
-# }
+# # # ...
+# # < HTTP/1.1 200 OK
+# # # ...
+# # {
+# #    "category" : "vacation",
+# #    "description" : "look up interesting towns in Sicily to visit",
+# #    "id" : 3
+# # }
 
-echo ""
-curl \
-   --verbose \
-   --request DELETE \
-   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
-   --header "X-CSRFToken: ${CSRF_TOKEN}" \
-   localhost:8000/api/tasks/2
+# echo ""
+# curl \
+#    --verbose \
+#    --request DELETE \
+#    --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+#    --header "X-CSRFToken: ${CSRF_TOKEN}" \
+#    localhost:8000/api/tasks/2
 
-# # ...
-# < HTTP/1.1 204 No Content
-# # ...
-# <no output>
-# ```
+# # # ...
+# # < HTTP/1.1 204 No Content
+# # # ...
+# # <no output>
+# # ```

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -24,13 +24,23 @@ line_with_csrf_token=$(grep "Set-Cookie:  csrftoken" $TEMP_FILE)
 if [[ $line_with_csrf_token =~ $regex ]]
 then
    CSRF_TOKEN="${BASH_REMATCH[1]}"
-   echo "identified the CSRF token to be equal to: ${CSRF_TOKEN}"
+   echo "identified the CSRF token to be equal to ${CSRF_TOKEN}"
 else
    echo "$line_with_csrf_token doesn't match" >&2
 fi
 
 
-export SESSION_ID=<tbd>
+# Extract the Session ID,
+# which is contained in the preceding command's output.
+regex="Set-Cookie:  sessionid=([0-9a-zA-Z]+);"
+line_with_session_id=$(grep "Set-Cookie:  sessionid" $TEMP_FILE)
+if [[ $line_with_session_id =~ $regex ]]
+then
+   SESSION_ID="${BASH_REMATCH[1]}"
+   echo "identified the Session ID to be equal to ${SESSION_ID}"
+else
+   echo "$line_with_session_id doesn't match" >&2
+fi
 
 # rm ${TEMP_FILE}
 # 

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -18,6 +18,8 @@ curl \
    }" \
    localhost:8000/api/sign_in
 
+cat ${TEMP_FILE}
+
 # # ...
 # < HTTP/1.1 204 No Content
 # # ...

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -26,7 +26,10 @@ cat ${TEMP_FILE}
 # <no output>
 # ```
 
-# Extract the CSRF token,
+# Adapt the example from
+# https://stackoverflow.com/questions/1891797/capturing-groups-from-a-grep-regex
+# in order to
+# extract the CSRF token,
 # which is contained in the preceding command's output.
 regex="Set-Cookie:  csrftoken=([0-9a-zA-Z]+);"
 line_with_csrf_token=$(grep "Set-Cookie:  csrftoken" $TEMP_FILE)
@@ -38,7 +41,10 @@ else
    echo "$line_with_csrf_token doesn't match" >&2
 fi
 
-# Extract the Session ID,
+# Adapt the example from
+# https://stackoverflow.com/questions/1891797/capturing-groups-from-a-grep-regex
+# in order to
+# extract the Session ID,
 # which is contained in the preceding command's output.
 regex="Set-Cookie:  sessionid=([0-9a-zA-Z]+);"
 line_with_session_id=$(grep "Set-Cookie:  sessionid" $TEMP_FILE)

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -22,6 +22,8 @@ echo ""
 curl \
    --verbose \
    localhost:8000/api/tasks \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    | json_pp
 
 # # ...
@@ -100,6 +102,8 @@ curl \
 
 echo ""
 curl localhost:8000/api/tasks \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    --verbose \
    | json_pp
 
@@ -149,6 +153,8 @@ curl \
 echo ""
 curl \
    --verbose \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    localhost:8000/api/tasks/3 \
    | json_pp
 
@@ -188,6 +194,8 @@ echo ""
 curl \
    --verbose \
    --request DELETE \
+   --header "Cookie: sessionid=${SESSION_ID}; csrftoken=${CSRF_TOKEN}" \
+   --header "X-CSRFToken: ${CSRF_TOKEN}" \
    localhost:8000/api/tasks/2
 
 # # ...

--- a/utility-scripts/populate-db.sh
+++ b/utility-scripts/populate-db.sh
@@ -1,10 +1,13 @@
+# Ensure that
+# this script will have access to the `USERNAME` and `PASSWORD` variables
+# from the following file:
 source .env
 
 # Arrange for every command to be printed before it is executed.
 set -o xtrace
 
 # Arrange for this script to exit immediately
-# if any subsequent(*) commands which fail.
+# if any one of the subsequent commands fails.
 set -e
 
 TEMP_FILE=response-with-sessionid-and-csrftoken.txt


### PR DESCRIPTION
this pull request implements an authentication subsystem
(as a newly-created Django app located in `src/auth_subsystem/`)

---

the implemented authentication subsystem is very rudimentary (and needs to be enhanced)
for the following reasons:

- currently, it is impossible to register/create a new `User` by issuing HTTP requests to the web application

- although this project is currently just a web backend (= web API),
  it configures (its installation of) the Django REST Framework
  to use `"rest_framework.authentication.SessionAuthentication"`
  (
  to the best of my knowledge,
  pure web backends typically use `TokenAuthentication` instead of `SessionAuthentication`
  )

that list of shortcomings intentionally accepted/tolerated in this pull request,
because my current priority is
to make it possible to run the containerized version of the project via Kubernetes
(
but neither of those shortcomings will be forgotten about -
cf. the last section in `README.md`
)